### PR TITLE
Add authentication and host configuration to Anthropic proxy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createXai } from "@ai-sdk/xai";
 import { spawn } from "child_process";
+import { randomUUID } from "crypto";
 import {
   createAnthropicProxy,
   type CreateAnthropicProxyOptions,
@@ -42,28 +43,60 @@ if (process.env.ANTHROPIC_API_KEY) {
   });
 }
 
-const proxyURL = createAnthropicProxy({
-  providers,
-});
+// Authentication token for the proxy. If the user already provided an
+// ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY, reuse it so Claude sends it as
+// Authorization: Bearer / X-Api-Key. Otherwise generate an ephemeral token and
+// inject it only into the spawned Claude process.
+const proxyAuthToken =
+  process.env.ANTHROPIC_AUTH_TOKEN ??
+  process.env.ANTHROPIC_API_KEY ??
+  randomUUID();
 
-if (process.env.PROXY_ONLY === "true") {
-  console.log("Proxy only mode: "+proxyURL);
-} else {
+const proxyAuthHeaderName = process.env.ANYCLAUDE_AUTH_HEADER ?? "X-AnyClaude-Token";
+
+// Allow overriding host/port via environment variables for flexibility. If
+// port is not provided, we bind to an ephemeral random port for parallel safety.
+const proxyHost = process.env.ANYCLAUDE_HOST || "127.0.0.1";
+const proxyPort = process.env.ANYCLAUDE_PORT
+  ? Number(process.env.ANYCLAUDE_PORT)
+  : undefined;
+
+(async () => {
+  const proxyURL = await createAnthropicProxy({
+    providers,
+    host: proxyHost,
+    port: proxyPort,
+    authToken: proxyAuthToken,
+    authHeaderName: proxyAuthHeaderName,
+  });
+
+  if (process.env.PROXY_ONLY === "true") {
+    console.log("Proxy only mode: " + proxyURL);
+    return;
+  }
+
   const claudeArgs = process.argv.slice(2);
   const proc = spawn("claude", claudeArgs, {
     env: {
       ...process.env,
       ANTHROPIC_BASE_URL: proxyURL,
+      // Ensure the Claude CLI includes our custom header via ANTHROPIC_CUSTOM_HEADERS
+      ANTHROPIC_CUSTOM_HEADERS: (() => {
+        const existing = process.env.ANTHROPIC_CUSTOM_HEADERS;
+        const line = `${proxyAuthHeaderName}: ${proxyAuthToken}`;
+        return existing ? `${existing}\n${line}` : line;
+      })(),
     },
     stdio: "inherit",
   });
   proc.on("exit", (code) => {
     if (claudeArgs[0] === "-h" || claudeArgs[0] === "--help") {
-      console.log("\nCustom Models:")
-      console.log("  --model <provider>/<model>      e.g. openai/o3");
+      console.log("\nCustom Models:");
+      console.log("  --model <provider>/<model>      e.g. openai/gpt-5-mini");
     }
-
-    process.exit(code);
+    process.exit(code ?? 0);
   });
-}
-
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
# Add authentication and host configuration to Anthropic proxy

This PR adds security and flexibility to the Anthropic proxy:

1. Added authentication support with a custom header token:
   - New `authToken` option to require authentication
   - Configurable `authHeaderName` (defaults to "X-AnyClaude-Token")
   - Returns 401 Unauthorized when token doesn't match

2. Added host configuration:
   - New `host` parameter (defaults to "127.0.0.1")
   - Properly reflects host in returned URL

3. Improved security for the CLI:
   - Generates a random UUID token if none provided
   - Injects token via ANTHROPIC_CUSTOM_HEADERS
   - Reuses existing API keys when available

4. Updated example model name in help text to "openai/gpt-5-mini"